### PR TITLE
Fix to Ivax satchels targetable by abilities.

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/UnitData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/UnitData.xml
@@ -9585,6 +9585,7 @@
     <CUnit id="SatchelLevel1">
         <Race value=""/>
         <FlagArray index="Invulnerable" value="1"/>
+        <FlagArray index="Untargetable" value="1"/>
         <EditorCategories value=""/>
         <LifeStart value="15"/>
         <LifeMax value="15"/>
@@ -9592,6 +9593,7 @@
     <CUnit id="SatchelLevel2">
         <Race value=""/>
         <FlagArray index="Invulnerable" value="1"/>
+        <FlagArray index="Untargetable" value="1"/>
         <EditorCategories value=""/>
         <LifeStart value="15"/>
         <LifeMax value="15"/>


### PR DESCRIPTION
PATCHNOTE:
-Ivax satchels can no longer be targeted by marine abilities (Niktos)

Fix to how satchels spawned by ivax in AC could be targeted with some non aoe skills.
Ivax and demo satchel abilites share a unit they create so this change will also affect demo satchels in same capacity.