### PR TITLE
Fix to assault hotkeys not being editable

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/UnitData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/UnitData.xml
@@ -3200,6 +3200,7 @@
         <SubgroupPriority value="9"/>
         <MinimapRadius value="0.2"/>
         <HotkeyCategory value="Hotkey/Heros"/>
+        <SelectAlias value="Assault"/>
     </CUnit>
     <CUnit id="Assault" parent="BaseHero">
         <DeathRevealFilters value="Visible;Player,Ally,Neutral,Missile,Dead,Hidden"/>


### PR DESCRIPTION
PATCHNOTE:
-Assault hotkeys can now be changed in Menu->Options->Hotkeys (Niktos)

This change unties him from his inherit of HOTS campaign tychus and makes him appear like if it's magic.
I didn't test it for unexpected things, it does not seem to infuence anything given what that field is.