### PR TITLE
Marksman concentration display issues fix.

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/RequirementData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/RequirementData.xml
@@ -353,8 +353,8 @@
         <NodeArray index="Show" Link="GTECountAbilAmmoFeedDummyCompleteOnlyAtUnitTechTreeCheat2"/>
     </CRequirement>
     <CRequirement id="ConcentrationLevel1">
-        <NodeArray index="Use" Link="GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat1"/>
-        <NodeArray index="Show" Link="GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat1"/>
+        <NodeArray index="Use" Link="EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat1"/>
+        <NodeArray index="Show" Link="EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat1"/>
     </CRequirement>
     <CRequirement id="CohesionLevel1">
         <NodeArray index="Use" Link="GTECountAbilCohesionCompleteOnlyAtUnitTechTreeCheat1"/>
@@ -365,12 +365,12 @@
         <NodeArray index="Show" Link="GTECountAbilCohesionCompleteOnlyAtUnitTechTreeCheat2"/>
     </CRequirement>
     <CRequirement id="ConcentrationLevel2">
-        <NodeArray index="Use" Link="GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat2"/>
-        <NodeArray index="Show" Link="GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat2"/>
+        <NodeArray index="Use" Link="EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat2"/>
+        <NodeArray index="Show" Link="EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat2"/>
     </CRequirement>
     <CRequirement id="ConcentrationLevel3">
-        <NodeArray index="Use" Link="GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat3"/>
-        <NodeArray index="Show" Link="GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat3"/>
+        <NodeArray index="Use" Link="EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat3"/>
+        <NodeArray index="Show" Link="EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat3"/>
     </CRequirement>
     <CRequirement id="CriticalStrikeLevel1">
         <NodeArray index="Use" Link="GTECountAbilCriticalStrikeCompleteOnlyAtUnit1"/>

--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/RequirementNodeData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/RequirementNodeData.xml
@@ -3,7 +3,6 @@
     <CRequirementConst id="10">
         <Tooltip value=""/>
     </CRequirementConst>
-    <CRequirementConst id="3"/>
     <CRequirementAllowAbil id="AllowAbil180611996TechTreeCheat">
         <Flags index="TechTreeCheat" value="1"/>
         <Index value="1"/>
@@ -308,7 +307,6 @@
     </CRequirementCountUnit>
     <CRequirementCountUpgrade id="CountUpgradeCriticalStrikeSkillCompleteOnly">
         <Flags index="TechTreeCheat" value="0"/>
-        <Tooltip value="RequirementNode/Tooltip/##id##"/>
         <Count Link="CriticalStrikeSkill" State="CompleteOnly"/>
     </CRequirementCountUpgrade>
     <CRequirementCountUpgrade id="CountUpgradeFireUpCompleteOnly">
@@ -344,6 +342,21 @@
         <Tooltip value=""/>
         <OperandArray index="0" value="CountAbilComingInHotCompleteOnlyAtUnit"/>
         <OperandArray index="1" value="2"/>
+    </CRequirementEq>
+    <CRequirementEq id="EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat1">
+        <Tooltip value="RequirementNode/Tooltip/##id##"/>
+        <OperandArray index="0" value="CountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat"/>
+        <OperandArray index="1" value="1"/>
+    </CRequirementEq>
+    <CRequirementEq id="EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat2">
+        <Tooltip value="RequirementNode/Tooltip/##id##"/>
+        <OperandArray index="0" value="CountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat"/>
+        <OperandArray index="1" value="2"/>
+    </CRequirementEq>
+    <CRequirementEq id="EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat3">
+        <Tooltip value="RequirementNode/Tooltip/##id##"/>
+        <OperandArray index="0" value="CountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat"/>
+        <OperandArray index="1" value="3"/>
     </CRequirementEq>
     <CRequirementEq id="EqCountAbilDisruptionTowerCompleteOnlyAtUnitTechTreeCheat1">
         <OperandArray index="0" value="CountAbilDisruptionTowerCompleteOnlyAtUnitTechTreeCheat"/>
@@ -535,18 +548,6 @@
     <CRequirementGTE id="GTECountAbilCohesionCompleteOnlyAtUnitTechTreeCheat2">
         <OperandArray index="0" value="CountAbilCohesionCompleteOnlyAtUnitTechTreeCheat"/>
         <OperandArray index="1" value="2"/>
-    </CRequirementGTE>
-    <CRequirementGTE id="GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat1">
-        <OperandArray index="0" value="CountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat"/>
-        <OperandArray index="1" value="1"/>
-    </CRequirementGTE>
-    <CRequirementGTE id="GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat2">
-        <OperandArray index="0" value="CountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat"/>
-        <OperandArray index="1" value="2"/>
-    </CRequirementGTE>
-    <CRequirementGTE id="GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat3">
-        <OperandArray index="0" value="CountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat"/>
-        <OperandArray index="1" value="3"/>
     </CRequirementGTE>
     <CRequirementGTE id="GTECountAbilCriticalStrikeCompleteOnlyAtUnit1">
         <OperandArray index="0" value="CountAbilCriticalStrikeCompleteOnlyAtUnit"/>
@@ -792,7 +793,6 @@
         <OperandArray index="1" value="1"/>
     </CRequirementGTE>
     <CRequirementGTE id="GTECountUpgradeCriticalStrikeSkillCompleteOnly1">
-        <Tooltip value="RequirementNode/Tooltip/##id##"/>
         <OperandArray index="0" value="CountUpgradeCriticalStrikeSkillCompleteOnly"/>
         <OperandArray index="1" value="1"/>
     </CRequirementGTE>

--- a/src/NOTD.SC2Map/enUS.SC2Data/LocalizedData/ObjectStrings.txt
+++ b/src/NOTD.SC2Map/enUS.SC2Data/LocalizedData/ObjectStrings.txt
@@ -9921,6 +9921,9 @@ RequirementNode/Name/EqCountAbilChemicalPlatingCompleteOnlyAtUnitTechTreeCheat2=
 RequirementNode/Name/EqCountAbilChemicalPlatingCompleteOnlyAtUnitTechTreeCheat3=CountAbil(ChemicalPlating,CompleteOnlyAtUnit)[TechTreeCheat] == 3
 RequirementNode/Name/EqCountAbilComingInHotCompleteOnlyAtUnit1=CountAbil(ComingInHot,CompleteOnlyAtUnit) == 1
 RequirementNode/Name/EqCountAbilComingInHotCompleteOnlyAtUnit2=CountAbil(ComingInHot,CompleteOnlyAtUnit) == 2
+RequirementNode/Name/EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat1=CountAbil(Concentration,CompleteOnlyAtUnit)[TechTreeCheat] == 1
+RequirementNode/Name/EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat2=CountAbil(Concentration,CompleteOnlyAtUnit)[TechTreeCheat] == 2
+RequirementNode/Name/EqCountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat3=CountAbil(Concentration,CompleteOnlyAtUnit)[TechTreeCheat] == 3
 RequirementNode/Name/EqCountAbilDisruptionTowerCompleteOnlyAtUnitTechTreeCheat1=CountAbil(DisruptionTower,CompleteOnlyAtUnit)[TechTreeCheat] == 1
 RequirementNode/Name/EqCountAbilDisruptionTowerCompleteOnlyAtUnitTechTreeCheat2=CountAbil(DisruptionTower,CompleteOnlyAtUnit)[TechTreeCheat] == 2
 RequirementNode/Name/EqCountAbilEnergyBatteryCompleteOnlyAtUnitTechTreeCheat1=CountAbil(EnergyBattery,CompleteOnlyAtUnit)[TechTreeCheat] == 1
@@ -9966,9 +9969,6 @@ RequirementNode/Name/GTECountAbilBuildTechnicianCompleteOnlyAtUnitTechTreeCheat1
 RequirementNode/Name/GTECountAbilBurrowUltraliskDownQueuedOnly2=CountAbil(BurrowUltraliskDown,QueuedOnly) >= 2
 RequirementNode/Name/GTECountAbilCohesionCompleteOnlyAtUnitTechTreeCheat1=CountAbil(Cohesion,CompleteOnlyAtUnit)[TechTreeCheat] >= 1
 RequirementNode/Name/GTECountAbilCohesionCompleteOnlyAtUnitTechTreeCheat2=CountAbil(Cohesion,CompleteOnlyAtUnit)[TechTreeCheat] >= 2
-RequirementNode/Name/GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat1=CountAbil(Concentration,CompleteOnlyAtUnit)[TechTreeCheat] >= 1
-RequirementNode/Name/GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat2=CountAbil(Concentration,CompleteOnlyAtUnit)[TechTreeCheat] >= 2
-RequirementNode/Name/GTECountAbilConcentrationCompleteOnlyAtUnitTechTreeCheat3=CountAbil(Concentration,CompleteOnlyAtUnit)[TechTreeCheat] >= 3
 RequirementNode/Name/GTECountAbilCriticalStrikeCompleteOnlyAtUnit1=CountAbil(CriticalStrike,CompleteOnlyAtUnit) >= 1
 RequirementNode/Name/GTECountAbilCriticalStrikeCompleteOnlyAtUnit2=CountAbil(CriticalStrike,CompleteOnlyAtUnit) >= 2
 RequirementNode/Name/GTECountAbilCriticalStrikeCompleteOnlyAtUnit3=CountAbil(CriticalStrike,CompleteOnlyAtUnit) >= 3


### PR DESCRIPTION
PATCHNOTE:
-Marksman concentration can no longer generate wrong level of buff icon(Niktos)

In some rare situations markman could gain 2 concentration stacks of different levels for example lvl2+lvl3, it had no gameplay impact just filled up already cluttered buff display.
With this fix markman can only gain concentration stacks of adequate level.