### PR TITLE
Pull #166 fix

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/BehaviorData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/BehaviorData.xml
@@ -717,11 +717,11 @@
     </CBehaviorBuff>
     <CBehaviorBuff id="CriticalStrikeDealer">
         <EditorCategories value="AbilityorEffectType:Units"/>
-        <Duration value="0.0002"/>
+        <Duration value="0.0627"/>
     </CBehaviorBuff>
     <CBehaviorBuff id="CriticalStrikeDefender">
         <EditorCategories value="AbilityorEffectType:Units"/>
-        <Duration value="0.0002"/>
+        <Duration value="0.0627"/>
         <InitialEffect value="AssaultCritEffects"/>
         <DamageResponse Chance="1" ModifyFraction="2">
             <Kind index="Spell" value="0"/>


### PR DESCRIPTION
PATCHNOTES:
-Fix to dealt critical damage failing to display since patch 2.176 (Niktos)

Fix to critical damage failing to display above marine introduced in pull #166