### PR TITLE
Refresher trigger->data fix

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/EffectData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/EffectData.xml
@@ -115,6 +115,7 @@
     <CEffectModifyUnit id="Refresher">
         <EditorCategories value=""/>
         <Cost Abil="Escape,Execute" CooldownOperation="Set"/>
+        <Cost Abil="Execute,Execute" CooldownOperation="Set"/>
         <Cost Abil="SupplyStation,Execute" CooldownOperation="Set"/>
         <Cost Abil="Sprint,Execute" CooldownOperation="Set"/>
         <Cost Abil="Flare,Execute" CooldownOperation="Set"/>


### PR DESCRIPTION
When rewriting refresher from trigger to data you overlooked Execute ability cooldown, and as such it wasn't reseting.
This adds it back to the list of abilities that refresh cooldowns.