### PR TITLE
FO mini snipers rocks attack fix.

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/WeaponData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/WeaponData.xml
@@ -292,7 +292,7 @@
         <EditorCategories value="Race:Terran"/>
         <Tip value="Button/Tooltip/M45AMarksmanRifle"/>
         <Icon value="Assets\Textures\btn-ability-terran-penetratorround.dds"/>
-        <TargetFilters value="Visible;Player,Ally,Neutral,Missile,Item,Stasis,Dead,Hidden,Invulnerable"/>
+        <TargetFilters value="Visible;Player,Ally,Missile,Item,Stasis,Dead,Hidden,Invulnerable"/>
         <Range value="16"/>
         <Marker Link="Weapon/C10CanisterRifle"/>
         <Cost>


### PR DESCRIPTION
FO minis in sniper gear could not attack rocks, this removes neutral units from not allowed targets.
WHY:
![mini why](https://user-images.githubusercontent.com/30372657/37535918-6b1c099a-2949-11e8-8331-4c53ff6f980a.png)
