### PR TITLE
X1 guardian lvl 2/3 attack actor error fix

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/ActorData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/ActorData.xml
@@ -12827,8 +12827,6 @@
         <On index="4" Terms="Effect.Bogus.Start; At Caster" Send="Create"/>
         <On index="5" Terms="Effect.X1EvisceratorBeamLevel2.Start; At Caster; FromEffectTreeDescendant" Send="ActionDamage"/>
         <On index="6" Terms="Effect.X1EvisceratorBeamLevel3.Start; At Caster; FromEffectTreeDescendant" Send="ActionDamage"/>
-        <On Terms="Effect.X1EvisceratorBeamLevel2.Start; At Caster" Send="Create DiamondbackAttackImpact"/>
-        <On Terms="Effect.X1EvisceratorBeamLevel3.Start; At Caster" Send="Create DiamondbackAttackImpact"/>
         <On Terms="Effect.X1EvisceratorBeamLevel2.Start; At Caster" Send="Create"/>
         <On Terms="Effect.X1EvisceratorBeamLevel3.Start; At Caster" Send="Create"/>
     </CActorAction>


### PR DESCRIPTION
X1 Guardian on lvl 2/3 while attacking was trying to create a non existing actor. Given the target actor didn't exists only impact of this change is debug window no longer gets filled up by errors. Those errors were just an annoyance during tests/debuging other issues with no implication on normal game.
Removing those 2 lines from actor, clears the erroneus action.