### PR TITLE
Fixing execute not working in patch 2.180

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/EffectData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/EffectData.xml
@@ -729,7 +729,7 @@
     </CEffectApplyBehavior>
     <CEffectSet id="ExecuteNormalTargetsSet">
         <EditorCategories value=""/>
-        <EffectArray value="ExecuteNormalTartgets"/>
+        <EffectArray value="ExecuteNormalTargets"/>
         <EffectArray value="ExecuteMovespeedBonus"/>
     </CEffectSet>
     <CEffectApplyBehavior id="ExecuteMovespeedBonus">


### PR DESCRIPTION
Typo strong, not sure how i didn't catch it in tests. Probably added the typo after them.

With the typo execute uses energy+gives movespeed boost but does not kill target.