### PR TITLE
Changing how nuke shows where it will deal damage on landing.

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/ActorData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/ActorData.xml
@@ -15696,4 +15696,8 @@
     <CActorRange id="nukeRange">
         <RangeFlags index="Minimap" value="1"/>
     </CActorRange>
+    <CActorModel id="GhostNukeIndicator">
+        <Model value="nukeCursorSplat"/>
+        <Scale value="9.500000"/>
+    </CActorModel>
 </Catalog>


### PR DESCRIPTION
WHY:
People mention how nuke shows a circle on ground and then deals damage in a bigger area since ancient times.
They also don't like nuke circle being same as arty calldowns circle
How it looks:
Old->
![old_indicator](https://user-images.githubusercontent.com/30372657/56469984-face0100-6440-11e9-9d3f-dcc5c5de2939.png)
New->
![new_indicator](https://user-images.githubusercontent.com/30372657/56469986-ff92b500-6440-11e9-871b-98505602cec5.png)

What was done:
Now nuke circle which gets drawn for people is the same circle that mando sees when aiming.

PATCHNOTE:
-Changing how nuke displays it's damage area to be more accurate.