### PR TITLE
Plasma visual stuck fix - maybe

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/ActorData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/ActorData.xml
@@ -9461,7 +9461,7 @@
         <On Terms="UnitBirth.*.Normal" Send="$Birth"/>
         <On Terms="ActorCreation" Send="AnimBaselineStop"/>
         <On Terms="AnimDone; AnimName Birth" Send="$Stand 0 -1.000000 -1.000000 3.000000 AsDuration"/>
-        <On Terms="AnimDone; AnimName Death" Send="Destroy"/>
+        <On Terms="AgeReached.PlasmaDetonator; Age 3.500000" Send="Destroy"/>
         <Model value="D8ClusterBomb"/>
         <BuildModel value="D8ClusterBomb"/>
         <DeathArray index="Normal" AnimProps="Death" ModelLink="D8Charge" SoundLink="Reaper_D8ChargeExplode"/>

--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/ActorData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/ActorData.xml
@@ -9461,7 +9461,7 @@
         <On Terms="UnitBirth.*.Normal" Send="$Birth"/>
         <On Terms="ActorCreation" Send="AnimBaselineStop"/>
         <On Terms="AnimDone; AnimName Birth" Send="$Stand 0 -1.000000 -1.000000 3.000000 AsDuration"/>
-        <On Terms="AgeReached.PlasmaDetonator; Age 3.500000" Send="Destroy"/>
+        <On Terms="AgeReached.PlasmaDetonator; Age 3.700000" Send="Destroy"/>
         <Model value="D8ClusterBomb"/>
         <BuildModel value="D8ClusterBomb"/>
         <DeathArray index="Normal" AnimProps="Death" ModelLink="D8Charge" SoundLink="Reaper_D8ChargeExplode"/>


### PR DESCRIPTION
Sometimes engy plasma charge circle stays on screen forever, i believe it's due to animation getting omitted by sc2 engine, similiar to how sometimes mm gets stuck mid osok or mando slides after gravnade.

Going by this assumption tying actor destruction to animation running it's course was the problem, so i changed it to get tied to actor age,


If it fixes plasmas getting stuck then that's cool, if it does not - it still functionally does same thing