### PR TITLE
Making sure circle showing chem plating aura is same size as aura itself.

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/ActorData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/ActorData.xml
@@ -1359,7 +1359,7 @@
         <On Terms="ActorCreation" Send="SetTintColor {0,255,38 20.000000}"/>
         <On Terms="Behavior.ChemicalPlatingAuraLevel3.Off" Send="Destroy"/>
         <Model value="NanitesUpgradeSplat"/>
-        <Scale value="1.150000"/>
+        <Scale value="1.800000"/>
     </CActorSplat>
     <CActorSplat id="ChemicalPlatingSplatLevel1" parent="GenericUnitSplat" unitName="ChemicalExpert">
         <On index="2" Terms="Behavior.ChemicalPlatingLevel1.On" Send="Create"/>


### PR DESCRIPTION
That thing turns out to be pretty big.
WHY:
![plating](https://user-images.githubusercontent.com/30372657/56470558-beea6a00-6447-11e9-9b19-f1b416761b27.png)

PATCHNOTE:
-Changing chem plating aura visual to proper size.