### PR TITLE
SC2 patch 5 fix pathfinder xp

### DIFF
--- a/src/NOTD.SC2Map/Base.SC2Data/GameData/UnitData.xml
+++ b/src/NOTD.SC2Map/Base.SC2Data/GameData/UnitData.xml
@@ -2408,7 +2408,7 @@
         <AbilArray Link="CurrentAmmo"/>
         <AbilArray Link="CurrentMagazine"/>
         <AbilArray Link="BlockInventoryTransfer"/>
-        <BehaviorArray index="0" Link="Basic_Hero"/>
+        <BehaviorArray Link="Basic_Hero"/>
         <BehaviorArray Link="KittenBeacon"/>
         <BehaviorArray Link="PersonalPropulsionSystem"/>
         <BehaviorArray Link="PersonalShieldGenerator"/>


### PR DESCRIPTION
As seen in diff, having `index="0"` breaks pathfinders behavior.

Possibly affects other areas of the game too, but too time consuming to do a full regression, so will need to make mr's when issues found.

Credit for identifying the issue goes to LeoTheCat

PATCH NOTES:
pathfinder xp behavior fixed (LeoTheCat)